### PR TITLE
Fixups

### DIFF
--- a/ESBreakerCLI/ParseStoryStrategies.cs
+++ b/ESBreakerCLI/ParseStoryStrategies.cs
@@ -69,7 +69,7 @@ namespace ESBreakerCLI
 								param.Text = savedItem["tr_text"];
 								item["tr_text"] = savedItem["tr_text"];
 							}
-							if (savedItem.ContainsKey("tr_buttons"))
+							if (!EmptyButton && savedItem.ContainsKey("tr_buttons"))
 							{
 								var idx = 0;
 								foreach (var button in (JsonArrayCollection)savedItem["tr_buttons"])

--- a/ESBreakerCLI/ParseTextStrategies.cs
+++ b/ESBreakerCLI/ParseTextStrategies.cs
@@ -592,7 +592,7 @@ namespace ESBreakerCLI
 							for (int idx = 0; idx < Count; idx++)
 							{
 								if (existingData[idx] != null &&
-								    existingData[idx]["jp_text"] == innerInformation.Name)
+								    existingData[idx]["jp_text"] == innerInformation.Name.TrimEnd())
 								{
 									savedItem = (JsonObjectCollection)existingData[idx];
 									existingData.RemoveAt(idx);


### PR DESCRIPTION
Item: Compare WITH an ending trim
   This will fix up the blanking items
Story: if the JP story database have empty buttons, do not keep TR version in the JSON
